### PR TITLE
Removed impassable node top for the cupola

### DIFF
--- a/configs/CLSKSOS.cfg
+++ b/configs/CLSKSOS.cfg
@@ -68,7 +68,6 @@
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		impassablenodes = node_stack_top
 	}
 }
 


### PR DESCRIPTION
The cupola did not allow kerbals to pass trough to other parts of the station
