### PR TITLE
Config: StationSciene - Removed Cyclotron and Spectrometron from having pasasble spaces

### DIFF
--- a/configs/CLSStationScience.cfg
+++ b/configs/CLSStationScience.cfg
@@ -7,15 +7,6 @@
 	}
 }
 
-@PART[StnSciCyclo]:HAS[!MODULE[ModuleConnectedLivingSpace]]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
-}
-
 @PART[StnSciExperiment1]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
     MODULE
@@ -71,15 +62,6 @@
 }
 
 @PART[StnSciLab]:HAS[!MODULE[ModuleConnectedLivingSpace]]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
-}
-
-@PART[StnSciSpectro]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
     MODULE
 	{


### PR DESCRIPTION
 (feedback from mod author).

Relevant forum post:
http://forum.kerbalspaceprogram.com/threads/54774-0-90-Station-Science-%28v1-4-0-90-compatibility%29?p=1315763&viewfull=1#post1315763
