### PR TITLE
Added surface attachment passability for KOSMOS SSPP

### DIFF
--- a/configs/CLSKosmos.cfg
+++ b/configs/CLSKosmos.cfg
@@ -4,6 +4,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  impassablenodes = top02
  }
  }
@@ -42,6 +43,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ passableWhenSurfaceAttached = True
  }
  }
  
@@ -51,6 +53,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -60,6 +63,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -69,6 +73,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -78,6 +83,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -87,6 +93,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -96,6 +103,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -105,6 +113,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  
@@ -114,6 +123,7 @@
  {
  name = ModuleConnectedLivingSpace
  passable = true
+ surfaceAttachmentsPassable = True
  }
  }
  


### PR DESCRIPTION
Made Kosmos_Berthing_Node_Single_Side passable when surface attached.
Allowed surface attachments to crewed elements to be passable.

This corrects behavior to intended for surface-attachable berthing node.