### PR TITLE
Add passability to stock short 1.25m to 0.625m adapter

### DIFF
--- a/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStock.cfg
+++ b/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStock.cfg
@@ -67,6 +67,16 @@
 	}
 }
 
+@PART[adapterSmallMiniShort]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		surfaceAttachmentsPassable = true
+	}
+}
+
 @PART[stationHub]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
 	MODULE


### PR DESCRIPTION
Given that the stock rockomax adapters are passable, and given that the 1.25m to 0.625m is literally just a hollow conic section, I can't see any reason not to assume it can be pressurized and let people travel through it.  That's why I'm suggesting it go here rather than the Freedom cfg.  Otherwise, transits between 1.25m to 0.625m modules are pretty tough, as all of the longer adapters look like they have fuel tanks or something in there.

Edit: Updated because I had my sizes wrong - but the reasoning still stands.  (I'm using the WildBlueIndustries set of parts that allow a bit more utility for 0.625m parts, including a passable docking port at that size.)
