### PR TITLE
Delete the default part config

### DIFF
--- a/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSDefaultPart.cfg
+++ b/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSDefaultPart.cfg
@@ -1,8 +1,0 @@
-@PART[*]:HAS[!MODULE[ModuleConnectedLivingSpace],!MODULE[ModuleEngines*],~category[Engine],~category[FuelTank],~category[Propulsion],~stagingIcon[],~name[K?S_*],#node_stack_top[*],#node_stack_bottom[*],~bulkheadProfiles[size0*],#bulkheadProfiles[size*]]:Final
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = false
-	}
-}


### PR DESCRIPTION
As far as I can tell this does precisely nothing useful. Parts without ModuleConnectedLivingSpace are not passable anyway, and this patch adds an annoying notification that parts aren't passable to things like convert-o-tron, SEP structural girder, engine nacelle and pre-cooler, etc.