### PR TITLE
Add support for vessels other than the active vessel

### DIFF
--- a/plugins/CLSInterfaces/Interfaces.cs
+++ b/plugins/CLSInterfaces/Interfaces.cs
@@ -49,11 +49,12 @@ namespace ConnectedLivingSpace
     public interface ICLSAddon
     {
         ICLSVessel Vessel { get; }
+        ICLSVessel getCLSVessel(Vessel v);
 
         bool AllowUnrestrictedTransfers { get; set; }
         bool RequestAddConnection(Part part1, Part part2);
         List<bool> RequestAddConnections(List<Part> part1, List<Part> part2);
         bool RequestRemoveConnection(Part part1, Part part2);
         List<bool> RequestRemoveConnections(List<Part> part1, List<Part> part2);
-  }
+    }
 }

--- a/plugins/ConnectedLivingSpace/CLSAddon.cs
+++ b/plugins/ConnectedLivingSpace/CLSAddon.cs
@@ -710,6 +710,14 @@ namespace ConnectedLivingSpace
     #endregion
 
     #region Support/action Methods
+    public ICLSVessel getCLSVessel(Vessel v)
+    {
+      if (v.rootPart == null) return null;
+      CLSVessel result = new CLSVessel();
+      result.Populate(v.rootPart);
+      return result;
+    }
+
     private void RebuildCLSVessel()
     {
       if (HighLogic.LoadedSceneIsFlight)


### PR DESCRIPTION
I was originally [going to do something](http://forum.kerbalspaceprogram.com/index.php?/topic/109972-130-connected-living-space-v1251-29-may-2017-customize-your-cls-parts/&do=findComment&comment=3072344) with RebuildCLSVessel(), but since it is entwined with active vessel, GUI, and recoupler support, I found it much easier to just add `getCLSVessel(Vessel v)` which simply takes a vessel and spits out a CLSVessel representation of it.

This accomplishes what I need, but it's not the most efficient approach, I think, and can be improved on.

A more thorough / elegant solution would require a deeper refactoring of CLS so that maintenance of vessel state is decoupled from GUI and other functionality -- will submit separate issue (#83) to propose and discuss those changes.