### PR TITLE
CLSB9.cfg updated

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,3 +10,11 @@
 
 	Merged PR from @kerbas-ad-astra
 		Some new parts
+
+1.2.5.5
+	Updated CLSB9.cfg:
+	Thanks to @Mine_Turtle:
+		I have added CDP docking port(supposed to be used with s2 parts) to the
+		list and made s2 crew parts passable, when surface attached. Reason: there
+		is no inline s2 docking adapter, nor it is possible to attach stock
+		docking ports to s2 modules and have crew transfers with CLS.

--- a/ConnectedLivingSpace.version
+++ b/ConnectedLivingSpace.version
@@ -6,7 +6,7 @@
     "MAJOR": 1,
     "MINOR": 2,
     "PATCH": 5,
-    "BUILD": 4
+    "BUILD": 5
   },
   "KSP_VERSION": {
     "MAJOR": 1,

--- a/Distribution/GameData/ConnectedLivingSpace/Configs/CLSB9.cfg
+++ b/Distribution/GameData/ConnectedLivingSpace/Configs/CLSB9.cfg
@@ -1,6 +1,6 @@
 @PART[InLineChute]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -9,7 +9,7 @@
 
 @PART[B9_Adapter_Y1]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -18,7 +18,7 @@
 
 @PART[B9_Adapter_SM3]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -27,7 +27,7 @@
 
 @PART[B9_Adapter_LM3]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -36,7 +36,7 @@
 
 @PART[B9_Adapter_SM2]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -45,7 +45,7 @@
 
 @PART[B9_Adapter_SM1]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -54,7 +54,7 @@
 
 @PART[B9_Adapter_C125]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -63,7 +63,7 @@
 
 @PART[B9_Cockpit_S2]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -73,7 +73,7 @@
 
 @PART[B9_Cockpit_S2_Body_Crew]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -82,7 +82,7 @@
 
 @PART[B9_Cockpit_S2_Body_Crew_6m]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -91,7 +91,7 @@
 
 @PART[B9_Cockpit_S2_Body]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -100,7 +100,7 @@
 
 @PART[B9_Cockpit_S2_Body_6m]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -109,7 +109,7 @@
 
 @PART[B9_Cockpit_S2_Adapter]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
+	MODULE
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
@@ -118,100 +118,111 @@
 
 @PART[B9_Cockpit_D25]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[HL_Aero_Cockpit]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_M27]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_MK2]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_S2]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_MK2_Body_Crew_2m]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_MK5]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
 
 @PART[B9_Cockpit_S2_Body_Crew]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }
 
 
 @PART[B9_Cockpit_S2_Body_Crew_6m]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
 }
 
 
 @PART[B9_Cockpit_S3]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
-    MODULE
-    {
-        name = ModuleConnectedLivingSpace
-        passable = true
-    }
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }
 
+@PART[B9_Utility_DockingPort_CDP]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		passableWhenSurfaceAttached = true
+	}
+}


### PR DESCRIPTION
Thanks to @Mine_Turtle:
I have added CDP docking port(supposed to be used with s2 parts) to the
list and made s2 crew parts passable, when surface attached. Reason: there
is no inline s2 docking adapter, nor it is possible to attach stock
docking ports to s2 modules and have crew transfers with CLS.