### PR TITLE
Update CLSStockFreedomAddon with 1.4 part configs

### DIFF
--- a/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStockFreedomAddon.txt
+++ b/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStockFreedomAddon.txt
@@ -79,3 +79,130 @@
 	}
 }
 
+// new configs for 1.4 (Squad/ and SquadExpansion/MakingHistory/ parts)
+
+@PART[Decoupler_0]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Decoupler_1]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Decoupler_2]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Decoupler_3]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_0]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_1]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_2]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_3]:HAS[!MODULE[ModuleConnectedLivingSpace]] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Decoupler_1p5]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Decoupler_4]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[InflatableAirlock]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_1p5]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Separator_4]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[Size1p5_Strut_Decoupler]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[SquadExpansion] 
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false // this is not an air-tight part by any stretch of the imagination, so including it here for completeness but setting its passability false
+	}
+}


### PR DESCRIPTION
Added "freedom" configs for the 1.4 (base and DLC) equivalents of the decouplers/separators that were already present from the previous version, as the naming scheme for them change in KSP's 1.4 release. DLC-only parts are marked with ':NEEDS[SquadExpansion]' and base-game 1.4 parts are unmarked.