### PR TITLE
Prevent log spam

### DIFF
--- a/ConnectedLivingSpace/CLSAddon.cs
+++ b/ConnectedLivingSpace/CLSAddon.cs
@@ -73,6 +73,8 @@ namespace ConnectedLivingSpace
 
     public static EventData<Vessel> onCLSVesselChange = new EventData<Vessel>("onCLSVesselChange");
 
+    internal static bool dynamicCrewCapacity = true;
+
     #endregion static Properties
 
     #region Instanced Properties
@@ -195,6 +197,10 @@ namespace ConnectedLivingSpace
       _settingsFile = $"{_settingsPath}/cls_settings.dat";
 
       _windowStyle = new GUIStyle(HighLogic.Skin.window);
+
+      // Dynamic crew capacity doesn't exist before KSP 1.4+; insulate older KSP versions from DCC code
+      if (Versioning.version_major < 1 || (Versioning.version_major == 1 && Versioning.version_minor < 4))
+        dynamicCrewCapacity = false;
 
       // load toolbar selection setting
       ApplySettings();

--- a/ConnectedLivingSpace/CLSPart.cs
+++ b/ConnectedLivingSpace/CLSPart.cs
@@ -58,7 +58,8 @@ namespace ConnectedLivingSpace
       }
 
       // Run check for dynamic crew capacity
-      CheckDCC();
+      if (CLSAddon.dynamicCrewCapacity)
+        CheckDCC();
     }
 
     public ICLSSpace Space


### PR DESCRIPTION
Code introduced in #100 uses KSP 1.4+ API, thus when run on older versions e.g. KSP 1.3.1 will spam the logfile with this error:  
`System.MissingFieldException: Field '.ModuleAnimateGeneric.CrewCapacity' not found.`

This is "harmless", since the code in question is only necessary in KSP 1.4+ anyway.  
The plugin would otherwise still function correctly on 1.3.x.

Gating the 1.4+ specific code behind a version check allows continuing support for KSP 1.3.x users without forcing them to use an older version of CLS. This seems desirable especially for players who are postponing their move to 1.4.x while Squad continues working through bugs and teething issues there.