### PR TITLE
Modernize CLSExtraplanetryLaunchpads.cfg

### DIFF
--- a/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSExtraplanetryLaunchpads.cfg
+++ b/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSExtraplanetryLaunchpads.cfg
@@ -2,7 +2,7 @@
 // https://github.com/skykooler/Extraplanetary-Launchpads/
 
 // Construction Workshop
-@PART[ExWorkshop]:HAS[!MODULE[ModuleConnectedLivingSpace]]
+@PART[ELWorkshop]:HAS[!MODULE[ModuleConnectedLivingSpace]]
 {
     MODULE
 	{


### PR DESCRIPTION
EPL no longer has parts called `Ex*`; they've all been renamed to `EL*`.