### PR TITLE
Making History mk2 command pod make top passable

### DIFF
--- a/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStockMakingHistory.cfg
+++ b/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Configs/CLSStockMakingHistory.cfg
@@ -34,7 +34,7 @@
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		impassablenodes = top, bottom
+		impassablenodes = bottom
 	}
 }
 


### PR DESCRIPTION
as per this forum post about the mk2 pod

https://forum.kerbalspaceprogram.com/index.php?/topic/109972-14x-connected-living-space-v1262-13-jun-2018/&do=findComment&comment=3329036

it should allow crew to pass through the top of the node, e.g. if you put docking port jr on it.