### PR TITLE
Fix version file URL property

### DIFF
--- a/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version
+++ b/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Connected Living Space",
-  "URL": "https://raw.githubusercontent.com/mwerle/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version",
+  "URL": "https://github.com/codepoetpbowden/ConnectedLivingSpace/raw/master/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version",
   "CHANGE_LOG_URL":"https://raw.githubusercontent.com/mwerle/ConnectedLivingSpace/CHANGELOG.md",
   "GITHUB":
   {


### PR DESCRIPTION
The current version file's URL property is a 404.
Now it's fixed.