### PR TITLE
Prevent string appending on each GetInfo() call

### DIFF
--- a/Source/ConnectedLivingSpace/ModuleConnectedLivingSpace.cs
+++ b/Source/ConnectedLivingSpace/ModuleConnectedLivingSpace.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -191,6 +191,11 @@ namespace ConnectedLivingSpace
     // Method to provide extra infomation about the part on response to the RMBof the part gallery
     public override string GetInfo()
     {
+      if (!string.IsNullOrEmpty(returnValue))
+      {
+        return returnValue;
+      }
+
       if (passable)
       {
         //returnValue += "Passable:  <color=" + XKCDColors.HexFormat.Lime + ">Yes</color>";


### PR DESCRIPTION
The information for `GetInfo()` is being appended to `returnString` on each call. This could potentially consume a lot of memory. It also leads to problems when used together with [PartInfo](https://github.com/linuxgurugamer/PartInfo) which calls GetInfo() a lot.

I propose to fix it by checking if `returnString` has been generated already and directly returning it.