### PR TITLE
Config for ReStock replacement models for stock command modules.

### DIFF
--- a/Distribution/CLSReStock.cfg
+++ b/Distribution/CLSReStock.cfg
@@ -1,0 +1,35 @@
+@PART[Mk2Pod]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ReStock,SquadExpansion]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[landerCabinSmall]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ReStock]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[mk2LanderCabin]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ReStock]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}
+
+@PART[mk2LanderCabin_v2]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ReStock]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}


### PR DESCRIPTION
ReStock replacement models include extra hatches and this adjusts the config to match the new models.
The patch in issue [#117](https://github.com/codepoetpbowden/ConnectedLivingSpace/issues/117) incorrectly references ReStockPlus and should be replaced by this pull request.

Tested on KSP 1.12.2.3167 with and without ReStock installed and CLS behaved as expected in both cases.