### PR TITLE
Line 29: Set "KSP_VERSION_MAX"."MINOR" to 12

### DIFF
--- a/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version
+++ b/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version
@@ -26,7 +26,7 @@
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
-    "MINOR": 11,
+    "MINOR": 12,
     "PATCH": 99
   }
 }


### PR DESCRIPTION
Current value is inconsistent with value for "KSP_VERSION" (line 19), and also causes CKAN to flag the mod as incompatible