### PR TITLE
Bug #112 - potential fix for handling surface-attached parts.

### DIFF
--- a/Source/ConnectedLivingSpace/CLSVessel.cs
+++ b/Source/ConnectedLivingSpace/CLSVessel.cs
@@ -234,9 +234,17 @@ namespace ConnectedLivingSpace
         }
         else
         {
-          // it is not possible to get into the child part from this part - it will need to be in a new space.
-          //Debug.Log("[CLS]:  The connection between 'this' part and the child part is NOT passable in both directions, so the child part will be added to a new space.");
-          spaceForChild = null;
+          // Bug #112 - check if the child-part is surface-attached AND that the child-part allows surface-attached parts to pass.
+          if (childNode?.nodeType == AttachNode.NodeType.Surface && PartHasPassableSurfaceAttachments(eChildren.Current))
+          {
+            spaceForChild = thisSpace;
+          }
+          else
+          {
+            // it is not possible to get into the child part from this part - it will need to be in a new space.
+            //Debug.Log("[CLS]:  The connection between 'this' part and the child part is NOT passable in both directions, so the child part will be added to a new space.");
+            spaceForChild = null;
+          }
         }
 
         // Having work out all the variables, make the recursive call


### PR DESCRIPTION
When a part is surface-attached and later the vessel is re-rooted so
that the surface-attached part is now "upstream" of the part it is
surface-attached to, CLS cannot correctly work out the Living Spaces.

This is because there is no valid attach-node from the surface-attached
part to the part it is surface-attached to.

This patch also looks at the surface-attached -connection from the other
direction to determine whether the connection should be passable or
not.